### PR TITLE
Version check refactoring

### DIFF
--- a/resources/xml-schema/rules-file-schema.xsd
+++ b/resources/xml-schema/rules-file-schema.xsd
@@ -110,6 +110,7 @@
 			<xs:enumeration value="hubspot"/>
 			<xs:enumeration value="odata"/>
 			<xs:enumeration value="http"/>
+			<xs:enumeration value="ibmmq"/>
 			<xs:enumeration value="idoc"/>
 			<xs:enumeration value="jdbc"/>
 			<xs:enumeration value="jira"/>
@@ -203,6 +204,7 @@
 			<xs:enumeration value="dropbox"/>
 			<xs:enumeration value="ftp"/>
 			<xs:enumeration value="https"/>
+			<xs:enumeration value="ibmmq"/>
 			<xs:enumeration value="idoc"/>
 			<xs:enumeration value="jms"/>
 			<xs:enumeration value="kafka"/>

--- a/src/org/cpilint/VersionCheckError.java
+++ b/src/org/cpilint/VersionCheckError.java
@@ -1,0 +1,14 @@
+package org.cpilint;
+
+@SuppressWarnings("serial")
+public final class VersionCheckError extends CpiLintError {
+	
+	public VersionCheckError(String message) {
+		super(message);
+	}
+	
+	public VersionCheckError(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/org/cpilint/model/DefaultXmlModel.java
+++ b/src/org/cpilint/model/DefaultXmlModel.java
@@ -59,6 +59,7 @@ final class DefaultXmlModel implements XmlModel {
 		receiverAdapterComponentTypes.put(ReceiverAdapter.HUBSPOT, "HubSpot");
 		receiverAdapterComponentTypes.put(ReceiverAdapter.ODATA, "HCIOData");
 		receiverAdapterComponentTypes.put(ReceiverAdapter.HTTP, "HTTP");
+		receiverAdapterComponentTypes.put(ReceiverAdapter.IBMMQ, "IBMMQ");
 		receiverAdapterComponentTypes.put(ReceiverAdapter.IDOC, "IDOC");
 		receiverAdapterComponentTypes.put(ReceiverAdapter.JDBC, "JDBC");
 		receiverAdapterComponentTypes.put(ReceiverAdapter.JIRA, "Jira");
@@ -98,6 +99,7 @@ final class DefaultXmlModel implements XmlModel {
 		senderAdapterComponentTypes.put(SenderAdapter.DROPBOX, "Dropbox");
 		senderAdapterComponentTypes.put(SenderAdapter.FTP, "FTP");
 		senderAdapterComponentTypes.put(SenderAdapter.HTTPS, "HTTPS");
+		senderAdapterComponentTypes.put(SenderAdapter.IBMMQ, "IBMMQ");
 		senderAdapterComponentTypes.put(SenderAdapter.IDOC, "IDOC");
 		senderAdapterComponentTypes.put(SenderAdapter.JMS, "JMS");
 		senderAdapterComponentTypes.put(SenderAdapter.KAFKA, "Kafka");

--- a/src/org/cpilint/model/DefaultXmlModel.java
+++ b/src/org/cpilint/model/DefaultXmlModel.java
@@ -128,6 +128,7 @@ final class DefaultXmlModel implements XmlModel {
 		httpEndpointPropertyKeyNames.put(ReceiverAdapter.HUBSPOT, List.of("addressURL"));
 		httpEndpointPropertyKeyNames.put(ReceiverAdapter.AZURECOSMOSDB, List.of("hostUrl"));
 		httpEndpointPropertyKeyNames.put(ReceiverAdapter.JIRA, List.of("address"));
+		httpEndpointPropertyKeyNames.put(ReceiverAdapter.IBMMQ, List.of("address"));
 		// Initialize the mappingTypePropertyKeys map.
 		mappingTypePropertyKeys = new HashMap<>();
 		mappingTypePropertyKeys.put(MappingType.MESSAGE_MAPPING, "mappingType");
@@ -287,6 +288,8 @@ final class DefaultXmlModel implements XmlModel {
 		    predicate = propertyKeyValuePredicate("ldapProxyType", "ldapProxyTypeOnPremise");
 		} else if (onPremReceiverAdapters.contains(receiverAdapter)) {
 		    predicate = propertyKeyValuePredicate("proxyType", "sapcc");
+		} else if (receiverAdapter == ReceiverAdapter.IBMMQ) {
+			predicate = propertyKeyValuePredicate("proxyType", "onPremise");
 		} else {
 		    // Not on-premise enabled.
 		    predicate = ModelUtil.xpathFalsePredicate();

--- a/src/org/cpilint/model/ReceiverAdapter.java
+++ b/src/org/cpilint/model/ReceiverAdapter.java
@@ -22,6 +22,7 @@ public enum ReceiverAdapter {
 	HUBSPOT("HubSpot"),
 	ODATA("OData"),
 	HTTP("HTTP"),
+	IBMMQ("IBMMQ"),
 	IDOC("IDoc"),
 	JDBC("JDBC"),
 	JIRA("Jira"),

--- a/src/org/cpilint/model/SenderAdapter.java
+++ b/src/org/cpilint/model/SenderAdapter.java
@@ -14,6 +14,7 @@ public enum SenderAdapter {
 	DROPBOX("Dropbox"),
 	FTP("FTP"),
 	HTTPS("HTTPS"),
+	IBMMQ("IBMMQ"),
 	IDOC("IDoc"),
 	JMS("JMS"),
 	KAFKA("Kafka"),

--- a/src/org/cpilint/rules/ReceiverAdaptersRuleFactory.java
+++ b/src/org/cpilint/rules/ReceiverAdaptersRuleFactory.java
@@ -29,6 +29,7 @@ public final class ReceiverAdaptersRuleFactory extends AllowDisallowRuleFactoryB
 		receiverAdapters.put("hubspot", ReceiverAdapter.HUBSPOT);
 		receiverAdapters.put("odata", ReceiverAdapter.ODATA);
 		receiverAdapters.put("http", ReceiverAdapter.HTTP);
+		receiverAdapters.put("ibmmq", ReceiverAdapter.IBMMQ);
 		receiverAdapters.put("idoc", ReceiverAdapter.IDOC);
 		receiverAdapters.put("jdbc", ReceiverAdapter.JDBC);
 		receiverAdapters.put("jira", ReceiverAdapter.JIRA);

--- a/src/org/cpilint/rules/SenderAdaptersRuleFactory.java
+++ b/src/org/cpilint/rules/SenderAdaptersRuleFactory.java
@@ -21,6 +21,7 @@ public final class SenderAdaptersRuleFactory extends AllowDisallowRuleFactoryBas
 		senderAdapters.put("dropbox", SenderAdapter.DROPBOX);
 		senderAdapters.put("ftp", SenderAdapter.FTP);
 		senderAdapters.put("https", SenderAdapter.HTTPS);
+		senderAdapters.put("ibmmq", SenderAdapter.IBMMQ);
 		senderAdapters.put("idoc", SenderAdapter.IDOC);
 		senderAdapters.put("jms", SenderAdapter.JMS);
 		senderAdapters.put("kafka", SenderAdapter.KAFKA);


### PR DESCRIPTION
The code that interacts with the GitHub API to retrieve the current CPILint version number has been moved to method retrieveCurrentVersion. All exceptions are recast as VersionCheckError, which is also new.